### PR TITLE
Add 'log' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ There's also a `fedup`-compatible wrapper script, so this works too:
 #### Finding upgrade logs
 
 Everything printed by `dnf` during the upgrade is in the system journal.
-Use `journalctl --list-boots` to show a list of system boots, and
-`journalctl -b -[NUM]` to display the log that corresponds to the upgrade.
+Run `dnf system-upgrade log` to see a list of boots during which an
+upgrade was attempted. Use `dnf system-upgrade log [NUM]`, where
+`[NUM]` is usually -1, to see the logs for that boot using journalctl.
 
 #### Enable debug shell on `/dev/tty9`
 

--- a/dnf-plugin-system-upgrade.spec
+++ b/dnf-plugin-system-upgrade.spec
@@ -10,8 +10,10 @@ Source0:    https://github.com/rpm-software-management/dnf-plugin-system-upgrade
 %if 0%{?fedora} >= 23
 # DNF in Fedora 23 uses Python 3 by default
 Requires: python3-%{name}
+Requires: python3-systemd
 %else
 Requires: python2-%{name}
+Requires: python-systemd
 %endif
 
 Provides: dnf-command(system-upgrade)

--- a/doc/dnf.plugin.system-upgrade.8
+++ b/doc/dnf.plugin.system-upgrade.8
@@ -12,6 +12,9 @@ dnf system\-upgrade \- upgrade a system to a new major release
 .B dnf system\-upgrade reboot
 .br
 .B dnf system\-upgrade clean
+.br
+.B dnf system\-upgrade log
+.RI [ NUMBER ]
 
 .SH DESCRIPTION
 .PP
@@ -27,6 +30,13 @@ completes successfully.
 .PP
 The \f[B]clean\f[] command can be used to remove previously\-downloaded
 data. This happens automatically at the end of a successful upgrade.
+.PP
+The \f[B]log\f[] command can be used to see a list of boots during
+which an upgrade was attempted. The logs for one of the boots can
+be shown by specifying one of the numbers in the first column.
+Negative numbers can be used to number the boots from last to first.
+In effect, \f[B]log -1\f[] can be used to see the logs for the last
+attempt.
 
 .SH OPTIONS
 .TP
@@ -70,7 +80,9 @@ dnf system\-upgrade reboot
 .EE
 
 .SH SEE ALSO
-dnf(8) dnf.conf(5)
+dnf(8),
+dnf.conf(5),
+journalctl(1)
 
 .SH AUTHORS
 Will Woods <wwoods@redhat.com>

--- a/system_upgrade.py
+++ b/system_upgrade.py
@@ -1,4 +1,4 @@
-"""system_upgrade.py - DNF plugin to handle major-version system upgrades."""
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2015 Red Hat, Inc.
 #
@@ -16,6 +16,8 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Author(s): Will Woods <wwoods@redhat.com>
+
+"""system_upgrade.py - DNF plugin to handle major-version system upgrades."""
 
 from __future__ import unicode_literals
 
@@ -238,10 +240,17 @@ def find_boots(message_id):
         yield entry
 
 def list_logs():
+    print(_('Following boots appear to contain upgrade logs:'))
+    n = -1
     for n, entry in enumerate(find_boots(ID_TO_IDENTIFY_BOOTS)):
-        print('{} / {}: {}'.format(n + 1,
-                                   entry['_BOOT_ID'],
-                                   entry['__REALTIME_TIMESTAMP'].isoformat()))
+        print('{} / {.hex}: {:%Y-%m-%d %H:%M:%S} {}→{}'.format(
+            n + 1,
+            entry['_BOOT_ID'],
+            entry['__REALTIME_TIMESTAMP'],
+            entry.get('SYSTEM_RELEASEVER', '??'),
+            entry.get('TARGET_RELEASEVER', '??')))
+    if n == -1:
+        print(_('-- no logs were found --'))
 
 def pick_boot(message_id, n):
     boots = list(find_boots(message_id))
@@ -304,7 +313,7 @@ def make_parser(prog):
                    help=argparse.SUPPRESS)
     g.add_argument('--no-downgrade', dest='distro_sync', action='store_false',
                    help=_("keep installed packages if the new release's version is older"))
-    # deprecated fedup options - action aliases
+    # deprecated fedup options — action aliases
     p.add_argument('--network',
                    help=argparse.SUPPRESS)
     p.add_argument('--clean',
@@ -314,11 +323,11 @@ def make_parser(prog):
         p.add_argument(arg, nargs=0, help=argparse.SUPPRESS, action=DeprecatedOption)
     for arg in ('--instrepo', '--product'):
         p.add_argument(arg, nargs=1, help=argparse.SUPPRESS, action=DeprecatedOption)
-    # deprecated fedup options - ignore silently
+    # deprecated fedup options — ignore silently
     p.add_argument('--skippkgs',
                    '--logtraceback',
                    help=argparse.SUPPRESS, action='store_false')
-    # deprecated fedup options - fail with error
+    # deprecated fedup options — fail with error
     p.add_argument(*REMOVED_OPTIONS.keys(),
                    nargs='?', help=argparse.SUPPRESS, action=RemovedOption)
     # and, semi-finally, the action itself


### PR DESCRIPTION
This should work as advertised in #11

```
$ dnf system-upgrade log
Following boots appear to contain upgrade logs:
1 / 412d0adf0bc947c1841a20b6fd35b94a: 2015-09-10 06:58:59 22→23

$ dnf system-upgrade log 1
...
```

The output and formatting are probably non-ideal, e.g. it might be better not to show the boot id. This probably can be adjusted later on if necessary.
