### PR TITLE
Fix test for deprecated args

### DIFF
--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -188,7 +188,7 @@ class ArgparseTestCase(unittest.TestCase):
     def assert_warning(self, args):
         with mock.patch('system_upgrade.logger.warning') as warning:
             self.cmd.parse_args(args)
-            warning.assert_called_once()
+            self.assertTrue(warning.called)
 
     def assert_error(self, args, message):
         with self.assertRaises(CliError) as cm:


### PR DESCRIPTION
Apparently there is no mock function assert_called_once. Python 3.5
started failing with non-existent calls to assert*. Under previous
versions this call wasn't doing anything.
