### PR TITLE
Always remove /system-update symlink on failure

### DIFF
--- a/dnf-system-upgrade.service
+++ b/dnf-system-upgrade.service
@@ -8,6 +8,8 @@ Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 # change $releasever - see https://bugzilla.redhat.com/show_bug.cgi?id=1212341
 EnvironmentFile=/system-update/.dnf-system-upgrade
 ExecStart=/usr/bin/dnf --releasever=${RELEASEVER} system-upgrade upgrade
+
+ExecStopPost=/usr/bin/rm -fv /system-update
 FailureAction=reboot
 
 [Install]


### PR DESCRIPTION
If something prevents the plugin from loading, the symlink would
not be removed, leading to reboot loops. Add a duplicate mechanism
to remove the symlink as a safety feature.

Note that the unit is conditionalized on
/system-update/.dnf-system-upgrade existing. It is not strictly
the same condition that is used to detect if it is "our" upgrade,
but it is close enough.

Fixes #37.
