### PR TITLE
Suppress "Failed to load environment files" error on service stop

### DIFF
--- a/dnf-system-upgrade.service
+++ b/dnf-system-upgrade.service
@@ -6,9 +6,10 @@ Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 [Service]
 # Upgrade output goes to journal and on-screen.
 StandardOutput=journal+console
+# This won't exist after we delete the symlink; don't consider that an error.
+EnvironmentFile=-/system-update/.dnf-system-upgrade
 # We need the --releasever junk because there's no way for DNF plugins to
 # change $releasever - see https://bugzilla.redhat.com/show_bug.cgi?id=1212341
-EnvironmentFile=/system-update/.dnf-system-upgrade
 ExecStart=/usr/bin/dnf --releasever=${RELEASEVER} system-upgrade upgrade
 # Remove the symlink if it's still there, to protect against reboot loops.
 ExecStopPost=/usr/bin/rm -fv /system-update

--- a/dnf-system-upgrade.service
+++ b/dnf-system-upgrade.service
@@ -4,12 +4,15 @@ ConditionPathExists=/system-update/.dnf-system-upgrade
 Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 
 [Service]
+# Upgrade output goes to journal and on-screen.
+StandardOutput=journal+console
 # We need the --releasever junk because there's no way for DNF plugins to
 # change $releasever - see https://bugzilla.redhat.com/show_bug.cgi?id=1212341
 EnvironmentFile=/system-update/.dnf-system-upgrade
 ExecStart=/usr/bin/dnf --releasever=${RELEASEVER} system-upgrade upgrade
-
+# Remove the symlink if it's still there, to protect against reboot loops.
 ExecStopPost=/usr/bin/rm -fv /system-update
+# If anything goes wrong, reboot back to the normal system.
 FailureAction=reboot
 
 [Install]


### PR DESCRIPTION
The upgrade process removes /system-upgrade/ when it starts, so
obviously the stop-post task won't be able to load the EnvironmentFile
from /system-upgrade/.dnf-system-upgrade.

Add the "-" so this isn't considered a failure, so the system shuts down
normally.

Resolves: RHBZ#1317215
