### PR TITLE
Add hidden --no-kernel option to skip kernel check

### DIFF
--- a/system_upgrade.py
+++ b/system_upgrade.py
@@ -361,6 +361,9 @@ def make_parser(prog):
     # hidden option for `reboot` testing
     p.add_argument('--no-reboot', dest='reboot', default=True,
                    action='store_false', help=argparse.SUPPRESS)
+    # hidden option to skip the kernel package check
+    p.add_argument('--no-kernel', dest='needkernel', default=True,
+                   action='store_false', help=argparse.SUPPRESS)
     return p
 
 # --- The actual Plugin and Command objects! ----------------------------------
@@ -613,8 +616,8 @@ class SystemUpgradeCommand(dnf.cli.Command):
 
     def transaction_download(self):
         # sanity check: we got a kernel, right?
-        downloads = self.cli.base.transaction.install_set
-        if not any(p.name.startswith('kernel') for p in downloads):
+        pkgs = self.cli.base.transaction.install_set
+        if self.opts.needkernel and not any(p.name.startswith('kernel') for p in pkgs):
             raise CliError(NO_KERNEL_MSG)
         # Okay! Write out the state so the upgrade can use it.
         system_ver = dnf.rpm.detect_releasever(self.base.conf.installroot)

--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -237,6 +237,12 @@ class ArgparseTestCase(unittest.TestCase):
                         '--logtraceback'):
             self.cmd.parse_args(["download", bad_arg])
 
+    def test_no_kernel(self):
+        self.cmd.opts = self.cmd.parse_args(["download"])
+        self.assertTrue(self.cmd.opts.needkernel)
+        self.cmd.opts = self.cmd.parse_args(["download", "--no-kernel"])
+        self.assertFalse(self.cmd.opts.needkernel)
+
     def test_removed_opts(self):
         for bad_arg in ('--expire-cache',
                         '--clean-metadata',
@@ -482,10 +488,8 @@ class DownloadCommandTestCase(CommandTestCase):
             self.assertEqual(repo.pkgdir, self.command.opts.datadir)
 
     def test_transaction_download(self):
-        pkg = mock.MagicMock()
-        pkg.name = "kernel"
-        self.cli.base.transaction.install_set = [pkg]
         self.command.opts = mock.MagicMock()
+        self.command.opts.needkernel = False
         self.command.opts.distro_sync = "distro_sync"
         self.cli.demands.allow_erasing = "allow_erasing"
         self.command.base.conf.best = "best"
@@ -500,6 +504,8 @@ class DownloadCommandTestCase(CommandTestCase):
 
     def test_transaction_download_no_kernel(self):
         self.cli.base.transaction.install_set = []
+        self.command.opts = mock.MagicMock()
+        self.command.opts.needkernel = True
         with self.assertRaises(CliError):
             self.command.transaction_download()
 


### PR DESCRIPTION
If you're using third-party repos for weird hardware with a special
kernel or something and you don't have (or need) a new kernel with your
upgrade, you should be able to skip this check.

Give the user enough rope to hang themselves with. That's the Unix Way!
