### PR TITLE
.service: use DefaultDependencies=no

### DIFF
--- a/dnf-system-upgrade.service
+++ b/dnf-system-upgrade.service
@@ -3,6 +3,11 @@ Description=System Upgrade
 ConditionPathExists=/system-update/.dnf-system-upgrade
 Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 
+DefaultDependencies=no
+Requires=sysinit.target
+After=sysinit.target systemd-journald.socket
+Before=shutdown.target
+
 [Service]
 # Upgrade output goes to journal and on-screen.
 StandardOutput=journal+console


### PR DESCRIPTION
This adjusts the service unit to follow guidelines from
systemd.offline-updates(7). In particular, the difference is that
we don't pull in basic.target any more, i.e. systemd will start much
less things for the update. This should result in more reliable /
cleaner upgrades.